### PR TITLE
[video_transcoder] 0.0.8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.8</span>**
+- update ffmpeg helper library to latest version
+
 **<span style="color:#56adda">0.0.7</span>**
 - Handle circumstance where file probe has no 'codec_name'
 - Improve library scan speed when used with other plugins that use ffprobe

--- a/info.json
+++ b/info.json
@@ -12,5 +12,5 @@
         "on_worker_process": 1
     },
     "tags": "video,ffmpeg",
-    "version": "0.0.7"
+    "version": "0.0.8"
 }


### PR DESCRIPTION
deleted and readded ffmpeg helper library to take advantage of new additions in the helper library since the plugin was originally made. Ran some recent cases where the "error" text would not allow the plugin to operate - this was fixed in the helper library several months ago, but plugins need to be updated to the latest helper library in order to have that fix.