### PR TITLE
Get correct directory for writing `.force_transcode` file

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -313,7 +313,7 @@ def on_postprocessor_task_results(data):
 
     # Mark the source file to be ignored on subsequent scans if 'force_transcode' was enabled
     if settings.get_setting('force_transcode'):
-        cache_directory = data.get('final_cache_path')
+        cache_directory = os.path.dirname(data.get('final_cache_path'))
         if os.path.exists(os.path.join(cache_directory, '.force_transcode')):
             directory_info = UnmanicDirectoryInfo(os.path.dirname(original_source_path))
             directory_info.set('video_transcoder', os.path.basename(original_source_path), 'force_transcoded')


### PR DESCRIPTION
As discussed [on Discord](https://discord.com/channels/819327740279914516/1194721147250540654), this bug means that the `.force_transcode` is actually never properly written to:

> The value returned by data.get('final_cache_path') is actually /tmp/unmanic/unmanic_file_conversion-dahwh-1705019796/It's Always Sunny in Philadelphia - S07E06 - The Storm of the Century Bluray-720p-gpdmc-1705020189.mkv. 

>So then on the next line, it's joining that value with .force_transcode, which gives the output /tmp/unmanic/unmanic_file_conversion-dahwh-1705019796/It's Always Sunny in Philadelphia - S07E06 - The Storm of the Century Bluray-720p-gpdmc-1705020189.mkv/.force_transcode 

> Now the actual file is at /tmp/unmanic/unmanic_file_conversion-dahwh-1705019796/.force_transcode, but since it's getting the final cache path of the file, not the folder the file is in, the if statement is getting false. That file it's looking for doesn't exist

This fix, suggested & tested by @yajrendrag, resolves it by getting the directory, instead of the file.