### PR TITLE
Pr video transcoder - missing generic_kwargs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.1.4</span>**
+- add missing 'generic_kwargs' from return statement in nvenc.py basic config section
+
 **<span style="color:#56adda">0.1.3</span>**
 - fix nvenc 10 bit profile name
 

--- a/info.json
+++ b/info.json
@@ -12,5 +12,5 @@
         "on_worker_process": 1
     },
     "tags": "video,ffmpeg",
-    "version": "0.1.3"
+    "version": "0.1.4"
 }

--- a/lib/encoders/nvenc.py
+++ b/lib/encoders/nvenc.py
@@ -183,7 +183,7 @@ class NvencEncoder:
                 '-profile:v:{}'.format(stream_id), str(defaults.get('nvenc_profile')),
             ]
             # TODO: Parse stream info to optimise these settings based on resolution, HDR, etc.
-            return stream_encoding
+            return generic_kwargs, stream_encoding
 
         # Add the preset and tune
         if self.settings.get_setting('nvenc_preset'):


### PR DESCRIPTION
in libs/encoders/nvenc.py, in the args function, in the basic mode, an error is generated:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/unmanic/libs/unplugins/executor.py", line 256, in execute_plugin_runner
    runner(data)
  File "/config/.unmanic/plugins/video_transcoder/plugin.py", line 250, in on_worker_process
    if mapper.streams_need_processing():
  File "/config/.unmanic/plugins/video_transcoder/lib/ffmpeg/stream_mapper.py", line 365, in streams_need_processing
    return self.__set_stream_mapping()
  File "/config/.unmanic/plugins/video_transcoder/lib/ffmpeg/stream_mapper.py", line 205, in __set_stream_mapping
    mapping = self.custom_stream_mapping(stream_info, self.video_stream_count)
  File "/config/.unmanic/plugins/video_transcoder/lib/plugin_stream_mapper.py", line 331, in custom_stream_mapping
    generic_kwargs, stream_encoding_args = nvenc_encoder.args(stream_info, stream_id)
ValueError: too many values to unpack (expected 2)
```

changing line 186 to:
`return generic_kwargs, stream_encoding`
fixes this issue.