### PR TITLE
use height for proportionate scaling instead of width

### DIFF
--- a/lib/plugin_stream_mapper.py
+++ b/lib/plugin_stream_mapper.py
@@ -159,14 +159,14 @@ class PluginStreamMapper(StreamMapper):
                 software_filters.append('crop={}'.format(self.crop_value))
             if self.settings.get_setting('target_resolution') not in ['source']:
                 vid_width, vid_height = self.scale_resolution(stream_info)
-                if vid_width:
-                    # Apply scale with only width to keep aspect ratio
+                if vid_height:
+                    # Apply scale with only height to keep aspect ratio
                     if self.settings.get_setting('video_encoder') in qsv_encoder.provides():
                         required_hw_smart_filters.append({'scale': [vid_width, vid_height]})
                     elif self.settings.get_setting('video_encoder') in nvenc_encoder.provides():
                         required_hw_smart_filters.append({'scale': [vid_width, vid_height]})
                     else:
-                        software_filters.append('scale={}:-1'.format(vid_width))
+                        software_filters.append('scale=-1:{}'.format(vid_height))
 
         # Apply custom software filters
         if self.settings.get_setting('apply_custom_filters'):


### PR DESCRIPTION
This switches the logic to use the height as the single passed dimension to keep aspect ratio instead of the width. When specifying if a video is 1080p or such, the main dimension that matters is the height. 

Because of the way it was currently set, when using this filter on a 4:3 4k video (`2880*2160`) to try and downscale to 1080p, it ends up with a resolution of `1920*1440` which is actually 1440p instead of the expected 1080p.

I referenced the scale docs to make sure I understood the logic correctly https://ffmpeg.org/ffmpeg-filters.html#scale and it looks like the `-1` just had to be moved to the width spot, and the `{}` needed to be moved to the height spot. Then it was just a matter of passing in `vid_height` instead of `vid_width`.