### PR TITLE
[video_trancoder] 0.1.7

### DIFF
--- a/lib/encoders/nvenc.py
+++ b/lib/encoders/nvenc.py
@@ -27,18 +27,15 @@ Notes:
         ffmpeg -h encoder=h264_nvenc
         ffmpeg -h encoder=hevc_nvenc
 """
-import re
 import logging
+import re
 import subprocess
-from functools import lru_cache
-from video_transcoder.lib.smart_output_target import SmartOutputTargetHelper
-from video_transcoder.lib.encoders.base import Encoder
 
+from video_transcoder.lib.encoders.base import Encoder
 
 logger = logging.getLogger("Unmanic.Plugin.video_transcoder")
 
 
-@lru_cache(maxsize=1)
 def list_available_cuda_devices():
     """
     Return a list of available CUDA devices via nvidia-smi.
@@ -46,9 +43,7 @@ def list_available_cuda_devices():
     gpu_dicts = []
     try:
         # Run the nvidia-smi command
-        result = subprocess.check_output(['nvidia-smi', '-L'], encoding='utf-8', timeout=2)
-        if not result:
-            raise ValueError("Failed to fetch available cuda devices")
+        result = subprocess.check_output(['nvidia-smi', '-L'], encoding='utf-8')
         # Use regular expression to find device IDs, names, and UUIDs
         gpu_info = re.findall(r'GPU (\d+): (.+) \(UUID: (.+)\)', result)
         # Populate the list of dictionaries for each GPU
@@ -57,134 +52,17 @@ def list_available_cuda_devices():
                 'hwaccel_device':      gpu_id,
                 'hwaccel_device_name': f"{gpu_name} (UUID: {gpu_uuid})",
             })
-    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        # nvidia-smi executable not found or command failed
-        raise ValueError("Failed to fetch available cuda devices")
-    except ValueError:
-        raise
-
+    except FileNotFoundError:
+        # nvidia-smi executable not found
+        return []
+    except subprocess.CalledProcessError:
+        # nvidia-smi command failed, likely no NVIDIA GPU present
+        return []
+    # Return the list of GPUs
     return gpu_dicts
 
 
-@lru_cache(maxsize=1)
-def _max_compute_capability():
-    """
-    Try to read the highest compute capability reported by nvidia-smi.
-    """
-    queries = [
-        ['nvidia-smi', '--query-gpu=compute_cap', '--format=csv,noheader'],
-        ['nvidia-smi', '--query-gpu=compute_capability', '--format=csv,noheader'],
-    ]
-    for cmd in queries:
-        try:
-            result = subprocess.check_output(cmd, encoding='utf-8', timeout=2)
-        except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
-            continue
-        if not result:
-            continue
-        caps = []
-        for line in result.splitlines():
-            cap_str = line.strip()
-            if not cap_str:
-                continue
-            try:
-                caps.append(float(cap_str))
-            except ValueError:
-                continue
-        if caps:
-            return max(caps)
-    raise ValueError("Failed to fetch compute capability via nvidia-smi")
-
-
-def is_pascal_or_newer():
-    """
-    Detect whether the available GPU(s) meet Pascal (6.x) compute capability or newer.
-    Returns:
-        True if Pascal+, False if definitively older, None if unknown.
-    """
-    try:
-        max_capability = _max_compute_capability()
-    except ValueError:
-        return None
-    if max_capability is None:
-        return None
-    return max_capability >= 6.0
-
-
-def is_turing_or_newer():
-    """
-    Detect whether the available GPU(s) meet Turing (7.5) compute capability or newer.
-    Returns:
-        True if Turing+, False if definitively older, None if unknown.
-    """
-    try:
-        max_capability = _max_compute_capability()
-    except ValueError:
-        return None
-    if max_capability is None:
-        return None
-    return max_capability >= 7.5
-
-
-@lru_cache(maxsize=None)
-def _supports_temporal_aq(encoder_name, hw_device):
-    """
-    Detect whether NVENC temporal AQ is supported by the configured GPU/driver for a specific encoder.
-    Returns:
-        True if supported, False if definitively unsupported, None if unknown.
-    """
-    if not encoder_name:
-        return None
-    # Normalize cache key inputs (lru_cache uses args).
-    device_idx = None if hw_device in (None, 'none') else str(hw_device)
-    cmd = [
-        'ffmpeg',
-        '-v', 'info',
-        '-nostdin',
-        '-f', 'lavfi',
-        '-i', 'testsrc=size=320x240:rate=1:duration=1',
-        '-frames:v', '1',
-        '-c:v', str(encoder_name),
-    ]
-    if device_idx is not None:
-        cmd += ['-gpu', device_idx]
-    cmd += ['-temporal-aq', '1', '-f', 'null', '-']
-
-    try:
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=4)
-        return True
-    except FileNotFoundError:
-        logger.info("ffmpeg not found while probing NVENC temporal AQ support.")
-        return None
-    except subprocess.TimeoutExpired:
-        logger.info("Timed out while probing NVENC temporal AQ support.")
-        return None
-    except subprocess.CalledProcessError as exc:
-        output = exc.output or ""
-        if isinstance(output, bytes):
-            output = output.decode(errors='ignore')
-        output_lower = output.lower()
-        failure_markers = (
-            "does not support temporal",
-            "temporal aq not supported",
-            "temporal aq: not supported",
-            "temporal aq not supported for this encoder",
-            "invalid param",
-            "unsupported parameter",
-            "unrecognized option 'temporal-aq'",
-        )
-        if any(marker in output_lower for marker in failure_markers):
-            return False
-        if "no nvenc capable devices" in output_lower or "no capable devices found" in output_lower:
-            return None
-        logger.info(
-            "NVENC temporal AQ probe failed; treating as unsupported. Output: %s",
-            output.strip(),
-        )
-        return False
-
-
-def get_configured_device_info(settings):
+def get_configured_device(settings):
     """
     Returns the currently configured device
     Checks to ensure that the configured device exists and otherwise will return the first device available
@@ -193,10 +71,7 @@ def get_configured_device_info(settings):
     """
     hardware_device = None
     # Set the hardware device
-    try:
-        hardware_devices = list_available_cuda_devices()
-    except ValueError:
-        hardware_devices = []
+    hardware_devices = list_available_cuda_devices()
     if not hardware_devices:
         # Return no options. No hardware device was found
         raise Exception("No NVIDIA device found")
@@ -204,7 +79,7 @@ def get_configured_device_info(settings):
     if settings.get_setting('nvenc_device') not in ['none']:
         # Attempt to match to that configured hardware device
         for hw_device in hardware_devices:
-            if str(settings.get_setting('nvenc_device')) == str(hw_device.get('hwaccel_device')):
+            if settings.get_setting('nvenc_device') == hw_device.get('hwaccel_device'):
                 hardware_device = hw_device
                 break
     # If no matching hardware device is set, then select the first one
@@ -216,94 +91,6 @@ def get_configured_device_info(settings):
 class NvencEncoder(Encoder):
     def __init__(self, settings=None, probe=None):
         super().__init__(settings=settings, probe=probe)
-
-    def _smart_basic_stream_args(self, stream_id, filter_state, target_encoder, hardware_device):
-        """
-        Build smart output target args for basic mode, returning the stream args list.
-        """
-        stream_args = []
-        smart_recommendation = None
-        provides = self.provides()
-        try:
-            helper = SmartOutputTargetHelper(self.probe)
-            file_path = None
-            try:
-                file_path = (self.probe.get_probe() or {}).get("format", {}).get("filename")
-            except Exception:
-                file_path = None
-            target_filters = {
-                "target_width":  filter_state.get("target_width") if filter_state else None,
-                "target_height": filter_state.get("target_height") if filter_state else None,
-                "scale_applied": filter_state.get("scale_applied") if filter_state else False,
-                "crop_applied":  filter_state.get("crop_applied") if filter_state else False,
-            }
-            source_stats = helper.collect_source_stats(file_path=file_path)
-            goal = self.settings.get_setting('smart_output_target')
-            target_codec = provides.get(target_encoder, {}).get('codec', 'h264')
-            target_supports_hdr10 = target_encoder in ("hevc_nvenc",)
-            smart_recommendation = helper.recommend_params(
-                goal,
-                source_stats,
-                target_filters,
-                target_codec,
-                target_encoder,
-                target_supports_hdr10,
-            )
-        except Exception as exc:
-            logger.info("Smart output target unavailable, falling back to defaults: %s", exc)
-
-        if smart_recommendation:
-            preset_value = "p7"
-            stream_args += ['-preset', str(preset_value)]
-
-            quality_mode = smart_recommendation.get("quality_mode")
-            quality_index = smart_recommendation.get("quality_index")
-            wants_cap = smart_recommendation.get("wants_cap")
-            rc_mode = "constqp" if quality_mode == SmartOutputTargetHelper.QUALITY_CONST else "vbr"
-            if rc_mode == "constqp" and wants_cap:
-                rc_mode = "vbr"
-            stream_args += [f'-rc:v:{stream_id}', rc_mode]
-
-            if rc_mode == "constqp":
-                if quality_index is not None:
-                    stream_args += [f'-qp:v:{stream_id}', str(int(quality_index))]
-            else:
-                if quality_index is not None:
-                    stream_args += [f'-cq:v:{stream_id}', str(int(quality_index))]
-                    # NVENC VBR target-quality mode still expects an average bitrate; set 0 so maxrate is the only rail.
-                    # REF: https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/nvenc-video-encoder-api-prog-guide/index.html?utm_source=chatgpt.com#finer-control-by-overriding-preset-parameters
-                    stream_args += [f'-b:v:{stream_id}', '0']
-                maxrate = smart_recommendation.get("maxrate")
-                bufsize = smart_recommendation.get("bufsize")
-                if maxrate:
-                    stream_args += [f'-maxrate:v:{stream_id}', str(int(maxrate))]
-                if bufsize:
-                    stream_args += [f'-bufsize:v:{stream_id}', str(int(bufsize))]
-
-            # Apply fixed lookahead/AQ defaults in encoder layer.
-            if rc_mode == "vbr":
-                stream_args += [f'-rc-lookahead:v:{stream_id}', '12']
-
-            if is_pascal_or_newer():
-                stream_args += [f'-aq-strength:v:{stream_id}', '8']
-                stream_args += [f'-spatial-aq:v:{stream_id}', '1']
-                if _supports_temporal_aq(target_encoder, hardware_device.get('hwaccel_device', 0)):
-                    stream_args += [f'-temporal-aq:v:{stream_id}', '1']
-            else:
-                logger.info("Skipping NVENC AQ because GPU compute capability is older than Pascal or indeterminate.")
-
-            logger.info(
-                "Smart output target applied (goal=%s, mode=%s, preset=%s, target=%sx%s, cap=%s, confidence=%s)",
-                smart_recommendation.get("goal"),
-                smart_recommendation.get("quality_mode"),
-                preset_value,
-                smart_recommendation.get("target_resolution", {}).get("width"),
-                smart_recommendation.get("target_resolution", {}).get("height"),
-                smart_recommendation.get("target_cap"),
-                smart_recommendation.get("confidence"),
-            )
-
-        return stream_args
 
     def _map_pix_fmt(self, is_h264: bool, is_10bit: bool) -> str:
         if is_10bit and not is_h264:
@@ -332,7 +119,6 @@ class NvencEncoder(Encoder):
             "nvenc_profile":                       "main",
             "nvenc_encoder_ratecontrol_method":    "auto",
             "nvenc_encoder_ratecontrol_lookahead": 0,
-            "nvenc_constant_quantizer_scale":      23,
             "nvenc_enable_spatial_aq":             False,
             "nvenc_enable_temporal_aq":            False,
             "nvenc_aq_strength":                   8,
@@ -346,20 +132,25 @@ class NvencEncoder(Encoder):
 
         :return:
         """
-        hardware_device = get_configured_device_info(self.settings)
+        hardware_device = get_configured_device(self.settings)
 
         generic_kwargs = {}
         advanced_kwargs = {}
+
         # Check if we are using a HW accelerated decoder also
         if self.settings.get_setting('nvenc_decoding_method') in ['cuda', 'nvdec', 'cuvid']:
             generic_kwargs = {
-                "-hwaccel_device":   hardware_device.get('hwaccel_device', 0),
+                "-hwaccel_device":   hardware_device.get('hwaccel_device'),
                 "-hwaccel":          self.settings.get_setting('nvenc_decoding_method'),
                 "-init_hw_device":   "cuda=hw",
                 "-filter_hw_device": "hw",
             }
             if self.settings.get_setting('nvenc_decoding_method') in ['cuda', 'nvdec']:
                 generic_kwargs["-hwaccel_output_format"] = "cuda"
+
+        # Prevent filter graph reconfiguration on mid-stream parameter changes
+        # (e.g., color space metadata changing partway through a file)
+        generic_kwargs["-reinit_filter"] = "0"
 
         return generic_kwargs, advanced_kwargs
 
@@ -420,6 +211,16 @@ class NvencEncoder(Encoder):
             chain.append("hwupload_cuda")
             start_filter_args.append(",".join(chain))
 
+        else:
+            # HW decode, no SW filters: output software frames to avoid
+            # hwaccel reconfiguration on mid-stream color space changes
+            generic_kwargs['-hwaccel_output_format'] = target_fmt
+            chain = [f"format={target_fmt}"]
+            if enc_supports_hdr and target_color_config.get('apply_color_params'):
+                chain.append(target_color_config['setparams_filter'])
+            chain.append("hwupload_cuda")
+            start_filter_args.append(",".join(chain))
+
         # Add the smart filters to the end
         end_filter_args += hw_smart_filters
 
@@ -433,24 +234,21 @@ class NvencEncoder(Encoder):
         }
 
     def encoder_details(self, encoder):
-        try:
-            hardware_devices = list_available_cuda_devices()
-        except ValueError:
-            hardware_devices = []
+        hardware_devices = list_available_cuda_devices()
         if not hardware_devices:
             # Return no options. No hardware device was found
             return {}
         provides = self.provides()
         return provides.get(encoder, {})
 
-    def stream_args(self, stream_info, stream_id, encoder_name, filter_state=None):
+    def stream_args(self, stream_info, stream_id, encoder_name):
         generic_kwargs = {}
         advanced_kwargs = {}
         encoder_args = []
         stream_args = []
 
         # Specify the GPU to use for encoding
-        hardware_device = get_configured_device_info(self.settings)
+        hardware_device = get_configured_device(self.settings)
         stream_args += ['-gpu', str(hardware_device.get('hwaccel_device', '0'))]
 
         # Handle HDR
@@ -475,25 +273,7 @@ class NvencEncoder(Encoder):
                 for k, v in target_color_config.get('stream_color_params', {}).items():
                     stream_args += [k, v]
 
-            smart_stream_args = []
-            smart_goal_enabled = (
-                self.settings.get_setting('enable_smart_output_target') and
-                filter_state and filter_state.get("execution_stage")
-            )
-            if smart_goal_enabled and self.probe:
-                smart_stream_args = self._smart_basic_stream_args(
-                    stream_id,
-                    filter_state,
-                    encoder_name,
-                    hardware_device,
-                )
-
-            if smart_stream_args:
-                stream_args += smart_stream_args
-            elif smart_goal_enabled:
-                stream_args += ['-preset', 'p7']
-            else:
-                stream_args += ['-preset', str(defaults.get('nvenc_preset'))]
+            stream_args += ['-preset', str(defaults.get('nvenc_preset'))]
 
             return {
                 "generic_kwargs":  generic_kwargs,
@@ -514,29 +294,17 @@ class NvencEncoder(Encoder):
         if self.settings.get_setting('nvenc_encoder_ratecontrol_method') in ['constqp', 'vbr', 'cbr']:
             # Set the rate control method
             stream_args += [f'-rc:v:{stream_id}', str(self.settings.get_setting('nvenc_encoder_ratecontrol_method'))]
-            if self.settings.get_setting('nvenc_encoder_ratecontrol_method') == 'constqp':
-                qp_value = self.settings.get_setting('nvenc_constant_quantizer_scale')
-                try:
-                    qp_value = int(qp_value)
-                except (TypeError, ValueError):
-                    qp_value = -1
-                if qp_value >= 0:
-                    stream_args += [f'-qp:v:{stream_id}', str(qp_value)]
         rc_la = int(self.settings.get_setting('nvenc_encoder_ratecontrol_lookahead') or 0)
         if rc_la > 0:
             stream_args += [f'-rc-lookahead:v:{stream_id}', str(rc_la)]
 
         # Apply adaptive quantization
         if self.settings.get_setting('nvenc_enable_spatial_aq'):
-            stream_args += [f'-spatial-aq:v:{stream_id}', '1']
+            stream_args += ['-spatial-aq', '1']
         if self.settings.get_setting('nvenc_enable_spatial_aq') or self.settings.get_setting('nvenc_enable_temporal_aq'):
             stream_args += [f'-aq-strength:v:{stream_id}', str(self.settings.get_setting('nvenc_aq_strength'))]
         if self.settings.get_setting('nvenc_enable_temporal_aq'):
-            temporal_aq_supported = _supports_temporal_aq(encoder_name, hardware_device.get('hwaccel_device', 0))
-            if not temporal_aq_supported:
-                logger.warning(
-                    "NVENC temporal AQ is configured, but this GPU does not appear to support it. This will likely fail.")
-            stream_args += [f'-temporal-aq:v:{stream_id}', '1']
+            stream_args += ['-temporal-aq', '1']
 
         # If CUVID is enabled, return generic_kwargs
         if (self.settings.get_setting('nvenc_decoding_method') or '').lower() in ['cuvid']:
@@ -574,7 +342,7 @@ class NvencEncoder(Encoder):
         if not getattr(self.settings, 'apply_default_fallbacks', True):
             return current_value
         if current_value not in available_options:
-            # Update in-memory setting for display only.
+            # Update in-memory setting for display only. 
             # IMPORTANT: do not persist settings from plugin.
             #   Only the Unmanic API calls should persist to JSON file.
             self.settings.settings_configured[key] = default_option
@@ -594,10 +362,7 @@ class NvencEncoder(Encoder):
             ]
         }
         default_option = None
-        try:
-            hardware_devices = list_available_cuda_devices()
-        except ValueError:
-            hardware_devices = []
+        hardware_devices = list_available_cuda_devices()
         if hardware_devices:
             values['select_options'] = []
             for hw_device in hardware_devices:
@@ -800,24 +565,6 @@ class NvencEncoder(Encoder):
             values["display"] = "hidden"
         return values
 
-    def get_nvenc_constant_quantizer_scale_form_settings(self):
-        # Lower is better
-        values = {
-            "label":          "Constant quantizer scale",
-            "description":    "Sets the quantizer when rate control is set to CQP. Lower values increase quality. Use -1 for NVENC defaults.",
-            "sub_setting":    True,
-            "input_type":     "slider",
-            "slider_options": {
-                "min": -1,
-                "max": 51,
-            },
-        }
-        if self.settings.get_setting('mode') not in ['standard']:
-            values["display"] = "hidden"
-        if self.settings.get_setting('nvenc_encoder_ratecontrol_method') != 'constqp':
-            values["display"] = "hidden"
-        return values
-
     def get_nvenc_enable_spatial_aq_form_settings(self):
         values = {
             "label":       "Enable Spatial Adaptive Quantization",
@@ -825,10 +572,6 @@ class NvencEncoder(Encoder):
                            "This helps in improving the quality of areas within a frame that are more detailed or complex.",
             "sub_setting": True,
         }
-        # Hide when hardware is definitively older than Pascal.
-        pascal_capable = is_pascal_or_newer()
-        if pascal_capable is False:
-            values["display"] = 'hidden'
         if self.settings.get_setting('mode') not in ['standard']:
             values["display"] = 'hidden'
         return values
@@ -838,14 +581,9 @@ class NvencEncoder(Encoder):
             "label":       "Enable Temporal Adaptive Quantization",
             "description": "This adjusts the quantization parameter across frames, based on the motion and temporal complexity.\n"
                            "This is particularly effective in scenes with varying levels of motion, enhancing quality where it's most needed.\n"
-                           "Support depends on the encoder/GPU combination. Ensure that your GPU supports this (Eg. at least Turing or newer hardware. Not a TU117 processor. Etc.).",
+                           "This option requires Turing or newer hardware.",
             "sub_setting": True,
         }
-        # Hide when hardware is definitively older than Turing.
-        # TODO: This changes depending on the encoder and hardware. Update this to use _supports_temporal_aq to detect if the GPU can use Temporal AQ.
-        turing_capable = is_turing_or_newer()
-        if turing_capable is False:
-            values["display"] = 'hidden'
         if self.settings.get_setting('mode') not in ['standard']:
             values["display"] = 'hidden'
         return values
@@ -866,9 +604,6 @@ class NvencEncoder(Encoder):
         }
         if self.settings.get_setting('mode') not in ['standard']:
             values["display"] = "hidden"
-        if (
-            not self.settings.get_setting('nvenc_enable_spatial_aq') and
-            not self.settings.get_setting('nvenc_enable_temporal_aq')
-        ):
+        if not self.settings.get_setting('nvenc_enable_spatial_aq'):
             values["display"] = "hidden"
         return values


### PR DESCRIPTION
The PR handles a situation where nvenc hardware decoding is used and the source content is encoded in such a way that the colorspace changes mid-stream.  Evidently this is fairly common as H.264 allows this and it seems it can happen in certain scenarios - e.g., HDHR OTA broadcast captures at commercial boundaries and others.

The fix uses a combination of a reinit_filter 0 option that is added as a keyword argument to instruct ffmpeg to ignore the colorspace change (so it keeps the existing filtergraph and not try to rebuild it) and then in the generate filtergraph function we add an explicit branch to handle the case of HW decode + no SW filters.  in the case of a colorspace change it would cause ffmpeg to detect a hwaccel change which it couldn't handle.  so we output frames instead to the CPU, the reinit_filter 0 option ignores the colorspace change, and then the frames get uploaded back to the GPU for encoding.

without this the plugin fails with a message similar to:
```
[vf#0:0 @ 0x6226cda844c0] Reconfiguring filter graph because hwaccel changed
Impossible to convert between the formats supported by the filter 'Parsed_null_0' and the filter 'auto_scale_0'
[vf#0:0 @ 0x6226cda844c0] Error reinitializing filters!
[vf#0:0 @ 0x6226cda844c0] Task finished with error code: -38 (Function not implemented)
[vf#0:0 @ 0x6226cda844c0] Terminating thread with return code -38 (Function not implemented)
[out#0/matroska @ 0x6226cd987b80] video:1550KiB audio:0KiB subtitle:0KiB other streams:0KiB global headers:0KiB muxing overhead: 0.100821%
frame=  120 fps=0.0 q=38.0 Lsize=    1551KiB time=00:00:04.90 bitrate=2588.8kbits/s speed=9.69x    
Conversion failed!
```
