### PR TITLE
[video_transcoder] 0.1.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+
+**<span style="color:#56adda">0.1.17</span>**
+- Add fixes to prevent error when doing hardware encode of file with streams that have have mid stream colorspace changes
+ 
 **<span style="color:#56adda">0.1.16</span>**
 - Add support for using the File Metadata helper for storing details on moved files (Requires Unmanic v0.3.0)
 - Fix issue with settings not chaing encoder when the codec changes

--- a/info.json
+++ b/info.json
@@ -12,5 +12,5 @@
         "on_worker_process": 1
     },
     "tags": "video,ffmpeg",
-    "version": "0.1.16"
+    "version": "0.1.17"
 }

--- a/lib/encoders/nvenc.py
+++ b/lib/encoders/nvenc.py
@@ -361,6 +361,10 @@ class NvencEncoder(Encoder):
             if self.settings.get_setting('nvenc_decoding_method') in ['cuda', 'nvdec']:
                 generic_kwargs["-hwaccel_output_format"] = "cuda"
 
+        # Prevent filter graph reconfiguration on mid-stream parameter changes
+        # (e.g., color space metadata changing partway through a file)
+        generic_kwargs["-reinit_filter"] = "0"
+
         return generic_kwargs, advanced_kwargs
 
     def generate_filtergraphs(self, current_filter_args, smart_filters, encoder_name):
@@ -414,6 +418,15 @@ class NvencEncoder(Encoder):
         # If we have no software filters:
         elif not hw_decode:
             # CPU decode -> setparams (if HDR) -> upload to CUDA
+            chain = [f"format={target_fmt}"]
+            if enc_supports_hdr and target_color_config.get('apply_color_params'):
+                chain.append(target_color_config['setparams_filter'])
+            chain.append("hwupload_cuda")
+            start_filter_args.append(",".join(chain))
+        else:
+            # HW decode, no SW filters: output software frames to avoid
+            # hwaccel reconfiguration on mid-stream color space changes
+            generic_kwargs['-hwaccel_output_format'] = target_fmt
             chain = [f"format={target_fmt}"]
             if enc_supports_hdr and target_color_config.get('apply_color_params'):
                 chain.append(target_color_config['setparams_filter'])


### PR DESCRIPTION
The PR handles a situation where nvenc hardware decoding is used and the source content is encoded in such a way that the colorspace changes mid-stream. Evidently this is fairly common as H.264 allows this and it seems it can happen in certain scenarios - e.g., HDHR OTA broadcast captures at commercial boundaries and others.

The fix uses a combination of a reinit_filter 0 option that is added as a keyword argument to instruct ffmpeg to ignore the colorspace change (so it keeps the existing filtergraph and not try to rebuild it) and then in the generate filtergraph function we add an explicit branch to handle the case of HW decode + no SW filters. in the case of a colorspace change it would cause ffmpeg to detect a hwaccel change which it couldn't handle. so we output frames instead to the CPU, the reinit_filter 0 option ignores the colorspace change, and then the frames get uploaded back to the GPU for encoding.

without this the plugin fails with a message similar to:

```
[vf#0:0 @ 0x6226cda844c0] Reconfiguring filter graph because hwaccel changed
Impossible to convert between the formats supported by the filter 'Parsed_null_0' and the filter 'auto_scale_0'
[vf#0:0 @ 0x6226cda844c0] Error reinitializing filters!
[vf#0:0 @ 0x6226cda844c0] Task finished with error code: -38 (Function not implemented)
[vf#0:0 @ 0x6226cda844c0] Terminating thread with return code -38 (Function not implemented)
[out#0/matroska @ 0x6226cd987b80] video:1550KiB audio:0KiB subtitle:0KiB other streams:0KiB global headers:0KiB muxing overhead: 0.100821%
frame=  120 fps=0.0 q=38.0 Lsize=    1551KiB time=00:00:04.90 bitrate=2588.8kbits/s speed=9.69x    
Conversion failed!
```