### PR TITLE
[video_transcoder] 0.1.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+
+**<span style="color:#56adda">0.1.17</span>**
+- adds nvenc_safe_decode option to allow plugin to avoid an error caused by colorspace changes in the file
+- adds new path in the define_filtergraph function to move the frames off the GPU to avoid h/w accel failure due to midstream colorspace changes
+- adds '-reinit_filter 0' option to the ffmpeg command line so that ffmpeg can ignore the filter change that would have resulted from the colorspace change
+- the combination of these allows ffmpeg to successfully process the file rather than failing
+ 
 **<span style="color:#56adda">0.1.16</span>**
 - Add support for using the File Metadata helper for storing details on moved files (Requires Unmanic v0.3.0)
 - Fix issue with settings not chaing encoder when the codec changes

--- a/info.json
+++ b/info.json
@@ -12,5 +12,5 @@
         "on_worker_process": 1
     },
     "tags": "video,ffmpeg",
-    "version": "0.1.16"
+    "version": "0.1.17"
 }

--- a/lib/encoders/nvenc.py
+++ b/lib/encoders/nvenc.py
@@ -327,6 +327,7 @@ class NvencEncoder(Encoder):
         return {
             "nvenc_device":                        "none",
             "nvenc_decoding_method":               "cpu",
+            "nvenc_safe_decode":                   False,
             "nvenc_preset":                        "p4",
             "nvenc_tune":                          "auto",
             "nvenc_profile":                       "main",
@@ -360,6 +361,11 @@ class NvencEncoder(Encoder):
             }
             if self.settings.get_setting('nvenc_decoding_method') in ['cuda', 'nvdec']:
                 generic_kwargs["-hwaccel_output_format"] = "cuda"
+
+        # Prevent filter graph reconfiguration on mid-stream parameter changes
+        # (e.g., color space metadata changing partway through a file)
+        if self.settings.get_setting('nvenc_safe_decode'):
+            generic_kwargs["-reinit_filter"] = "0"
 
         return generic_kwargs, advanced_kwargs
 
@@ -414,6 +420,16 @@ class NvencEncoder(Encoder):
         # If we have no software filters:
         elif not hw_decode:
             # CPU decode -> setparams (if HDR) -> upload to CUDA
+            chain = [f"format={target_fmt}"]
+            if enc_supports_hdr and target_color_config.get('apply_color_params'):
+                chain.append(target_color_config['setparams_filter'])
+            chain.append("hwupload_cuda")
+            start_filter_args.append(",".join(chain))
+        # HW decode, no SW filters:
+        elif self.settings.get_setting('nvenc_safe_decode'):
+            # output software frames to avoid
+            # hwaccel reconfiguration on mid-stream color space changes
+            generic_kwargs['-hwaccel_output_format'] = target_fmt
             chain = [f"format={target_fmt}"]
             if enc_supports_hdr and target_color_config.get('apply_color_params'):
                 chain.append(target_color_config['setparams_filter'])
@@ -640,6 +656,18 @@ class NvencEncoder(Encoder):
             ]
         }
         if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        return values
+
+    def get_nvenc_safe_decode_form_settings(self):
+        values = {
+            "label": "Safe decode mode",
+            "description": "Forces CPU-side frame handling to prevent failures on files with "
+                           "inconsistent color space metadata (common in WEBDL sources).\n"
+                           "Slightly slower due to GPU->CPU->GPU round-trip per frame.",
+            "sub_setting": True,
+        }
+        if self.settings.get_setting('mode') not in ['standard'] or self.settings.get_setting('nvenc_decoding_method') == "cpu":
             values["display"] = "hidden"
         return values
 


### PR DESCRIPTION
The PR handles a situation where nvenc hardware decoding is used and the source content is encoded in such a way that the colorspace changes mid-stream. Evidently this is fairly common as H.264 allows this and it seems it can happen in certain scenarios - e.g., HDHR OTA broadcast captures at commercial boundaries and others.

The fix uses a combination of a reinit_filter 0 option that is added as a keyword argument to instruct ffmpeg to ignore the colorspace change (so it keeps the existing filtergraph and not try to rebuild it) and then in the generate filtergraph function we add an explicit branch to handle the case of HW decode + no SW filters. in the case of a colorspace change it would cause ffmpeg to detect a hwaccel change which it couldn't handle. so we output frames instead to the CPU, the reinit_filter 0 option ignores the colorspace change, and then the frames get uploaded back to the GPU for encoding.

without this the plugin fails with a message similar to:

```
[vf#0:0 @ 0x6226cda844c0] Reconfiguring filter graph because hwaccel changed
Impossible to convert between the formats supported by the filter 'Parsed_null_0' and the filter 'auto_scale_0'
[vf#0:0 @ 0x6226cda844c0] Error reinitializing filters!
[vf#0:0 @ 0x6226cda844c0] Task finished with error code: -38 (Function not implemented)
[vf#0:0 @ 0x6226cda844c0] Terminating thread with return code -38 (Function not implemented)
[out#0/matroska @ 0x6226cd987b80] video:1550KiB audio:0KiB subtitle:0KiB other streams:0KiB global headers:0KiB muxing overhead: 0.100821%
frame=  120 fps=0.0 q=38.0 Lsize=    1551KiB time=00:00:04.90 bitrate=2588.8kbits/s speed=9.69x    
Conversion failed!
```

this fix is gated within the plugin by the use of a new option: nvenc_safe_decode.  if enabled, this will pass all frames through the CPU (decode and encode still done entirely in hardware) so the ffmpeg can avoid a failure.  if nvenc_safe_decode is disabled, then all frames stay on the GPU, but if a midstream metadata change ocurrs that would cause ffmpeg to reinitialize the filtergraph it will cause a failure.  the use of nvenc_safe_decode can be coupled with  the reprocess_file plugin to automate this so the user can first try to process with all frames remaining on the GPU (nvenc_safe_decode disabled) but if it errors, the reprocess_plugin can be used to add the file back to the task queue to a duplicate library where everythng is the same except nvenc_safe_decode is enabled.