### PR TITLE
[video_transcoder] 0.1.18

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,11 @@
 
+**<span style="color:#56adda">0.1.18</span>**
+- adds similar logic for qsv and vaapi as was done for nvenc in 0.1.17
+- adds new qsv_safe_decode and vaapi_safe_decode options to the respective encoders
+- adds new paths in their respective define_filtergraph functions to move the frames off the GPU to avoid h/w accel failure due to midstream colorspace changes
+- adds '-reinit_filter 0' option to the ffmpeg command line when the x_safe_option is enabled so that ffmpeg can ignore the filter change that would have resulted from the colorspace change
+- the combination of these allows ffmpeg to successfully process the file rather than failing
+
 **<span style="color:#56adda">0.1.17</span>**
 - adds nvenc_safe_decode option to allow plugin to avoid an error caused by colorspace changes in the file
 - adds new path in the define_filtergraph function to move the frames off the GPU to avoid h/w accel failure due to midstream colorspace changes

--- a/info.json
+++ b/info.json
@@ -12,5 +12,5 @@
         "on_worker_process": 1
     },
     "tags": "video,ffmpeg",
-    "version": "0.1.17"
+    "version": "0.1.18"
 }

--- a/lib/encoders/qsv.py
+++ b/lib/encoders/qsv.py
@@ -150,6 +150,7 @@ class QsvEncoder(Encoder):
     def options(self):
         return {
             "qsv_decoding_method":            "cpu",
+            "qsv_safe_decode":                False,
             "qsv_preset":                     "slow",
             "qsv_encoder_ratecontrol_method": "LA_ICQ",
             "qsv_constant_quantizer_scale":   "25",
@@ -176,6 +177,10 @@ class QsvEncoder(Encoder):
                 "-hwaccel":               "qsv",
                 "-hwaccel_output_format": "qsv",
             })
+
+        if self.settings.get_setting('qsv_safe_decode'):
+            generic_kwargs["-reinit_filter"] = "0"
+
         return generic_kwargs, advanced_kwargs
 
     def generate_filtergraphs(self, current_filter_args, smart_filters, encoder_name):
@@ -238,13 +243,22 @@ class QsvEncoder(Encoder):
                 # Upload to hw frames at the end of the filter
                 end_chain = start_chain + ["hwupload=extra_hw_frames=64", "format=qsv", f"vpp_qsv=format={target_fmt}"]
                 end_filter_args.append(",".join(end_chain))
+            elif self.settings.get_setting('qsv_safe_decode'):
+                # HW decode + safe mode: force SW frames to avoid hwaccel reconfigure
+                generic_kwargs['-hwaccel_output_format'] = target_fmt
+                start_chain = [f"format={target_fmt}"]
+                if enc_supports_hdr and target_color_config.get('apply_color_params'):
+                    start_chain.append(target_color_config['setparams_filter'])
+                start_filter_args.append(",".join(start_chain))
+                end_chain = start_chain + ["hwupload=extra_hw_frames=64", "format=qsv", f"vpp_qsv=format={target_fmt}"]
+                end_filter_args.append(",".join(end_chain))
             else:
-                # Add hwupload filter that can handle when the frame was decoded in software or hardware
+                # Pure HW path - frames stay in QSV memory
                 chain = [f"format={target_fmt}|qsv",
                          "hwupload=extra_hw_frames=64",
                          "format=qsv", f"vpp_qsv=format={target_fmt}"]
                 end_filter_args.append(",".join(chain))
-
+                
         # Add the smart filters to the end
         end_filter_args += hw_smart_filters
 
@@ -412,6 +426,18 @@ class QsvEncoder(Encoder):
         }
         self.__set_default_option(values['select_options'], 'qsv_decoding_method', 'cpu')
         if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        return values
+
+    def get_qsv_safe_decode_form_settings(self):
+        values = {
+            "label": "Safe decode mode",
+            "description": "Forces CPU-side frame handling to prevent failures on files with "
+                           "inconsistent color space metadata (common in WEBDL sources).\n"
+                           "Slightly slower due to GPU->CPU->GPU round-trip per frame.",
+            "sub_setting": True,
+        }
+        if self.settings.get_setting('mode') not in ['standard'] or self.settings.get_setting('qsv_decoding_method') != "qsv":
             values["display"] = "hidden"
         return values
 

--- a/lib/encoders/vaapi.py
+++ b/lib/encoders/vaapi.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -89,6 +90,7 @@ class VaapiEncoder(Encoder):
         return {
             "vaapi_device":                     "none",
             "vaapi_decoding_method":            "cpu",
+            "vaapi_safe_decode":                False,
             "vaapi_encoder_ratecontrol_method": "ICQ",
             "vaapi_constant_quantizer_scale":   "25",
             "vaapi_constant_quality_scale":     "23",
@@ -140,6 +142,9 @@ class VaapiEncoder(Encoder):
                 "-vaapi_device": hardware_device.get('hwaccel_device_path'),
             }
             advanced_kwargs = {}
+
+        if self.settings.get_setting('vaapi_safe_decode'):
+            generic_kwargs["-reinit_filter"] = "0"
 
         return generic_kwargs, advanced_kwargs
 
@@ -203,11 +208,20 @@ class VaapiEncoder(Encoder):
                 # Upload to hw frames at the end of the filter
                 end_chain = start_chain + ["hwupload"]
                 end_filter_args.append(",".join(end_chain))
+            elif self.settings.get_setting('vaapi_safe_decode'):
+                # HW decode + safe mode: force SW frames to avoid hwaccel reconfigure
+                generic_kwargs['-hwaccel_output_format'] = target_fmt
+                start_chain = [f"format={target_fmt}"]
+                if enc_supports_hdr and target_color_config.get('apply_color_params'):
+                    start_chain.append(target_color_config['setparams_filter'])
+                start_filter_args.append(",".join(start_chain))
+                end_chain = start_chain + ["hwupload"]
+                end_filter_args.append(",".join(end_chain))
             else:
-                # Add hwupload filter that can handle when the frame was decoded in software or hardware
+                # Pure HW path - frames stay in VAAPI memory
                 chain = [f"format={target_fmt}|vaapi", "hwupload"]
                 end_filter_args.append(",".join(chain))
-
+                
         # Add the smart filters to the end
         end_filter_args += hw_smart_filters
 
@@ -382,6 +396,18 @@ class VaapiEncoder(Encoder):
             values["display"] = "hidden"
         return values
 
+    def get_vaapi_safe_decode_form_settings(self):
+        values = {
+            "label": "Safe decode mode",
+            "description": "Forces CPU-side frame handling to prevent failures on files with "
+                           "inconsistent color space metadata (common in WEBDL sources).\n"
+                           "Slightly slower due to GPU->CPU->GPU round-trip per frame.",
+            "sub_setting": True,
+        }
+        if self.settings.get_setting('mode') not in ['standard'] or self.settings.get_setting('vaapi_decoding_method') != "vaapi":
+            values["display"] = "hidden"
+        return values
+    
     def get_vaapi_encoder_ratecontrol_method_form_settings(self):
         values = {
             "label":          "Encoder ratecontrol method",


### PR DESCRIPTION
This PR makes the same modifications to qsv and vaapi encoders as was made for nvenc in v0.1.7:

The PR handles a situation where qsv/vaapi hardware decoding is used and the source content is encoded in such a way that the colorspace changes mid-stream. Evidently this is fairly common as H.264 allows this and it seems it can happen in certain scenarios - e.g., HDHR OTA broadcast captures at commercial boundaries and others.

The fix uses a combination of a reinit_filter 0 option that is added as a keyword argument to instruct ffmpeg to ignore the colorspace change (so it keeps the existing filtergraph and not try to rebuild it) and then in the generate filtergraph function we add an explicit branch to handle the case of HW decode + no SW filters. in the case of a colorspace change it would cause ffmpeg to detect a hwaccel change which it couldn't handle. so we output frames instead to the CPU, the reinit_filter 0 option ignores the colorspace change, and then the frames get uploaded back to the GPU for encoding.

without this the plugin fails with a message similar to:
```
[fc#0 @ 0x55853af42c40] Reconfiguring filter graph because hwaccel changed
Impossible to convert between the formats supported by the filter 'scaler_out_#0:0' and the filter 'auto_scale_0'
[fc#0 @ 0x55853af42c40] Error reinitializing filters!
[fc#0 @ 0x55853af42c40] Task finished with error code: -38 (Function not implemented)
[fc#0 @ 0x55853af42c40] Terminating thread with return code -38 (Function not implemented)
[out#0/matroska @ 0x55853af59300] video:1073KiB audio:25271KiB subtitle:35KiB other streams:0KiB global headers:0KiB muxing overhead: 0.310660%
frame=  155 fps= 44 q=-0.0 Lsize=   26461KiB time=00:00:06.29 bitrate=34419.2kbits/s speed=1.78x    
Conversion failed!
```
this fix is gated within the plugin by the use of a new option: qsv_safe_decode/vaapi_safe_decode. if enabled, this will pass all frames through the CPU (decode and encode still done entirely in hardware) so the ffmpeg can avoid a failure. if qsv_safe_decode/vaapi_safe_decode is disabled, then all frames stay on the GPU, but if a midstream metadata change ocurrs that would cause ffmpeg to reinitialize the filtergraph it will cause a failure. the use of qsv_safe_decode/vaapi_safe_decode can be coupled with the reprocess_file plugin to automate this so the user can first try to process with all frames remaining on the GPU (qsv_safe_decode/vaapi_safe_decode disabled) but if it errors, the reprocess_plugin can be used to add the file back to the task queue to a duplicate library where everything is the same except qsv_safe_decode/vaapi_safe_decode is enabled.