### PR TITLE
[video_transcoder] 0.0.19

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 
+**<span style="color:#56adda">0.1.19</span>**
+- adds the -reinit_filter:0 option for all decode modes of vaapi and qsv when h/w encode is used.
+- Needed since vaapi & qsv use hwupload to get the frame into GPU memory and will generate an error if reinit_filter is not set to 0
+
 **<span style="color:#56adda">0.1.18</span>**
 - adds similar logic for qsv and vaapi as was done for nvenc in 0.1.17
 - adds new qsv_safe_decode and vaapi_safe_decode options to the respective encoders

--- a/info.json
+++ b/info.json
@@ -12,5 +12,5 @@
         "on_worker_process": 1
     },
     "tags": "video,ffmpeg",
-    "version": "0.1.18"
+    "version": "0.1.19"
 }

--- a/lib/encoders/qsv.py
+++ b/lib/encoders/qsv.py
@@ -166,9 +166,11 @@ class QsvEncoder(Encoder):
         """
         # Encode only (no decoding)
         #   REF: https://trac.ffmpeg.org/wiki/Hardware/QuickSync#Transcode
+        # set reinit_filter here for both h/w & s/w decode paths as both use hwupload
         generic_kwargs = {
             "-init_hw_device":   "qsv=qsv0",
             "-filter_hw_device": "qsv0",
+            "-reinit_filter":    "0",
         }
         advanced_kwargs = {}
         # Check if we are using a HW accelerated decoder> Modify args as required
@@ -177,9 +179,6 @@ class QsvEncoder(Encoder):
                 "-hwaccel":               "qsv",
                 "-hwaccel_output_format": "qsv",
             })
-
-        if self.settings.get_setting('qsv_safe_decode'):
-            generic_kwargs["-reinit_filter"] = "0"
 
         return generic_kwargs, advanced_kwargs
 

--- a/lib/encoders/vaapi.py
+++ b/lib/encoders/vaapi.py
@@ -127,12 +127,14 @@ class VaapiEncoder(Encoder):
             dev_id = 'vaapi0'
             # Configure args such that when the input may or may not be able to be decoded with hardware we can do:
             #   REF: https://trac.ffmpeg.org/wiki/Hardware/VAAPI#Encoding
+            # set reinit_filter here for both h/w & s/w decode paths as both use hwupload
             generic_kwargs = {
                 "-init_hw_device":        "vaapi={}:{}".format(dev_id, hardware_device.get('hwaccel_device_path')),
                 "-hwaccel":               "vaapi",
                 "-hwaccel_output_format": "vaapi",
                 "-hwaccel_device":        dev_id,
                 "-filter_hw_device":      dev_id,
+                "-reinit_filter":         "0",
             }
             advanced_kwargs = {}
         else:
@@ -142,9 +144,6 @@ class VaapiEncoder(Encoder):
                 "-vaapi_device": hardware_device.get('hwaccel_device_path'),
             }
             advanced_kwargs = {}
-
-        if self.settings.get_setting('vaapi_safe_decode'):
-            generic_kwargs["-reinit_filter"] = "0"
 
         return generic_kwargs, advanced_kwargs
 


### PR DESCRIPTION
the change in v0.0.18 to add reinit_filter when doing h/w decode for vaapi and qsv also need to be done when using CPU decode + h/w encode.  Both of these scenarios still use hwupload to get the frame to the GPU so will generate an error without this. (note nvenc does not do this in the case of CPU decode + h/w encode).  So this change sets `-reinit_filter: 0` for both h/w and s/w decode when using vaapi encode or qsv encode.