### PR TITLE
Update plugin_stream_mapper.py

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.1.19</span>**
+- Corrected encoder options setting in plugin stream mapper for libsvtav1
+
 **<span style="color:#56adda">0.1.18</span>**
 - adds similar logic for qsv and vaapi as was done for nvenc in 0.1.17
 - adds new qsv_safe_decode and vaapi_safe_decode options to the respective encoders

--- a/info.json
+++ b/info.json
@@ -12,5 +12,5 @@
         "on_worker_process": 1
     },
     "tags": "video,ffmpeg",
-    "version": "0.1.18"
+    "version": "0.1.19"
 }

--- a/lib/plugin_stream_mapper.py
+++ b/lib/plugin_stream_mapper.py
@@ -413,7 +413,7 @@ class PluginStreamMapper(StreamMapper):
                     stream_encoding += stream_args.get("encoder_args", [])
                     stream_encoding += stream_args.get("stream_args", [])
                 elif encoder_name in stva1_encoder.provides():
-                    stream_args = vaapi_encoder.stream_args(stream_info, stream_id, encoder_name, filter_state=filter_state)
+                    stream_args = stva1_encoder.stream_args(stream_info, stream_id, encoder_name, filter_state=filter_state)
                     stream_encoding += stream_args.get("encoder_args", [])
                     stream_encoding += stream_args.get("stream_args", [])
                 elif encoder_name in qsv_encoder.provides():


### PR DESCRIPTION
Set the proper encoder for stva1_encoder when checking encoder args.  This was causing a bug when utilizing libsvtav1 where the args were not properly set.  This led to CRF being excluded and "-rc_mode ICQ -global_quality 23" being added.